### PR TITLE
update build scripts to map source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "homepage": "https://github.com/marcellabillett/DeveloperWarRoom#readme",
   "main": "index.js",
   "scripts": {
-    "build": "webpack -p",
-    "watch": "webpack --watch",
+    "build": "webpack --devtool source-map",    
+    "build:prod": "webpack -p",
+    "watch": "webpack --devtool source-map --watch",
     "lint": "./node_modules/eslint/bin/eslint.js --ext .js,.jsx src/",
     "lint:fix": "./node_modules/eslint/bin/eslint.js --ext .js,.jsx src/ --fix",
     "test": "echo \"Error: no test specified\" && exit 0"


### PR DESCRIPTION
We can define a `devtools: source-map` in the config file to allow us access to the originating source code error when an error occurs; but I had a little trouble configuring this to not be included in the production build for publication. 
So we just pass this option into webpack using the CLI `--devtool <source code mapping option>`